### PR TITLE
3-support-more-datatypes:

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,11 +309,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
- "time",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -534,10 +531,9 @@ dependencies = [
 
 [[package]]
 name = "dbdump"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-std",
- "chrono",
  "clap",
  "sqlx",
 ]
@@ -744,7 +740,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1523,6 +1519,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "digest",
@@ -1678,17 +1675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,12 +1778,6 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "dbdump"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
+author = "William Cherry (wcherry69@gmail.com)"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sqlx = { version = "0.6.3", features = [ "runtime-async-std-native-tls", "mysql", "offline", "macros", "bigdecimal"  ] }
+sqlx = { version = "0.6.3", features = [ "runtime-async-std-native-tls", "mysql", "offline", "macros", "bigdecimal", "chrono"  ] }
 async-std = { version = "1", features = [ "attributes" ] }
 clap = { version = "4.2.1", features = ["derive", "env"] }
-chrono = "0.4.24"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+rel=`grep -o '^version\s*=\s*".*"' Cargo.toml | sed   's/version = "\(.*\)"/\1/'`
+echo Building release ${rel}
+cargo clean
+cargo build --release
+cargo build --release --target x86_64-apple-darwin
+mkdir target/artifacts
+cd target/artifacts
+mkdir macos
+mkdir macos/intel
+mkdir macos/apple
+cp ../release/dbdump ./macos/intel
+cp ../x86_64-apple-darwin/release/dbdump ./macos/apple
+zip -r release-${rel}-macos.zip .
+cd ../..
+echo Build Completed...
+
+# CARGO_PKG_VERSION

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,24 @@
 mod std_writer;
 
-use chrono;
 use clap::Parser;
+
 use sqlx::mysql::{MySqlColumn, MySqlPoolOptions, MySqlRow};
+use sqlx::types::chrono::Local;
+use sqlx::types::chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use sqlx::types::BigDecimal;
 use sqlx::{Column, Row};
 use std_writer::StdWriter;
 
 /// Standalone database dump tool
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None, arg_required_else_help(true))]
 struct Args {
     /// Schema to extract
     #[arg(short, long, default_value_t = String::from("test"))]
     schema: String,
 
     /// Database url to connect to
-    #[arg(short, long, env = "DATABASE_URL")]
+    #[arg(short, long)]
     url: String,
 
     /// Extract schema only
@@ -34,6 +36,14 @@ struct Args {
     /// Use single row inserts
     #[arg(long = "single-row-inserts", required = false, default_value_t = false)]
     single_row_inserts: bool,
+
+    /// BETA: Skip any datatype we don't understand - set the field to null
+    #[arg(
+        long = "beta-skip-unknown-datatypes",
+        required = false,
+        default_value_t = false
+    )]
+    skip_unknown_datatypes: bool,
 }
 
 #[async_std::main]
@@ -103,7 +113,7 @@ async fn main() -> Result<(), sqlx::Error> {
 
                 let cols = data.columns().len();
                 for i in 0..cols - 1 {
-                    let value = cast_data(&data, i);
+                    let value = cast_data(&data, i, args.skip_unknown_datatypes);
                     if let Some(value) = value {
                         w.print(format!("{},", value).as_str());
                     } else {
@@ -111,7 +121,7 @@ async fn main() -> Result<(), sqlx::Error> {
                     }
                 }
 
-                let value = cast_data(&data, cols - 1);
+                let value = cast_data(&data, cols - 1, args.skip_unknown_datatypes);
                 if let Some(value) = value {
                     w.print(format!("{}", value).as_str());
                 } else {
@@ -133,63 +143,62 @@ async fn main() -> Result<(), sqlx::Error> {
             }
         }
     }
-    w.println("SET FOREIGN_KEY_CHECKS=0;");
+    w.println("SET FOREIGN_KEY_CHECKS=1;");
     w.flush();
     Ok(())
 }
 
-fn cast_data(row: &MySqlRow, index: usize) -> Option<String> {
-    let result = row.try_get::<i64, usize>(index);
-    if result.is_ok() {
-        return if let Some(value) = result.ok() {
-            Option::Some(value.to_string())
-        } else {
-            None
-        };
+pub fn cast_data(row: &MySqlRow, index: usize, skip_unknown_datatypes: bool) -> Option<String> {
+    let col = row.column(index);
+    let type_name = col.type_info().to_string();
+
+    /*
+    This check protects against null data - lots of trail and error to get to this particular code that actually works
+    */
+    if row.try_get_unchecked::<&str, usize>(index).ok().is_none()
+        && row.try_get_unchecked::<i64, usize>(index).ok().is_none()
+    {
+        return None;
     }
 
-    let result = row.try_get::<i32, usize>(index);
-    if result.is_ok() {
-        return if let Some(value) = result.ok() {
-            Option::Some(value.to_string())
-        } else {
-            None
-        };
+    match type_name.as_str() {
+        "BOOLEAN" => Some(row.get::<bool, usize>(index).to_string()),
+        "TINYINT" => Some(row.get::<i8, usize>(index).to_string()),
+        "SMALLINT" => Some(row.get::<i16, usize>(index).to_string()),
+        "INT" => Some(row.get::<i32, usize>(index).to_string()),
+        "BIGINT" => Some(row.get::<i64, usize>(index).to_string()),
+        "TINYINT UNSIGNED" => Some(row.get::<u8, usize>(index).to_string()),
+        "SMALLINT UNSIGNED" => Some(row.get::<u16, usize>(index).to_string()),
+        "INT UNSIGNED" => Some(row.get::<u32, usize>(index).to_string()),
+        "BIGINT UNSIGNED" => Some(row.get::<u64, usize>(index).to_string()),
+        "FLOAT" => Some(row.get::<f32, usize>(index).to_string()),
+        "DOUBLE" => Some(row.get::<f64, usize>(index).to_string()),
+        "CHAR" => Some(quote(row.get::<String, usize>(index))),
+        "VARCHAR" => Some(quote(row.get::<String, usize>(index))),
+        "TEXT" => Some(quote(row.get::<String, usize>(index))),
+        "TIMESTAMP" => Some(quote(row.get::<DateTime<Utc>, usize>(index).to_string())),
+        "DATETIME" => Some(quote(row.get::<NaiveDateTime, usize>(index).to_string())),
+        "DATE" => Some(quote(row.get::<NaiveDate, usize>(index).to_string())),
+        "TIME" => Some(quote(row.get::<NaiveTime, usize>(index).to_string())),
+        "DECIMAL" => Some(row.get::<BigDecimal, usize>(index).to_string()),
+        // "AddOtherTypesHere" => Some(row.get::<i64, usize>(index).to_string()),
+        // Add support for Binary data
+        "VARBINARY" => None,
+        "BINARY" => None,
+        "BLOB" => None,
+
+        _ => {
+            if skip_unknown_datatypes {
+                None
+            } else {
+                panic!("The database type {} is not implemented in this version of dbdump. Please try to download a more recent version or report a bug if you are on the most recent version", type_name)
+            }
+        }
     }
+}
 
-    let result = row.try_get::<BigDecimal, usize>(index);
-    if result.is_ok() {
-        return if let Some(value) = result.ok() {
-            Option::Some(value.to_string())
-        } else {
-            None
-        };
-    }
-
-    let result = row.try_get::<String, usize>(index);
-    if result.is_ok() {
-        return if let Some(value) = result.ok() {
-            Option::Some(format!("'{}'", value))
-        } else {
-            None
-        };
-    }
-
-    let result = row.try_get::<bool, usize>(index);
-    if result.is_ok() {
-        return if let Some(value) = result.ok() {
-            Option::Some(value.to_string())
-        } else {
-            None
-        };
-    }
-
-    println!(
-        "\n\n\n!!!!!!!!!!!!!!!!!!!!!!!!! Failed to parse data: {:?} !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n\n\n",
-        row.try_get::<String, usize>(index).err()
-    );
-
-    None
+fn quote(str: String) -> String {
+    format!("'{}'", str)
 }
 
 fn compute_column_name(columns: &[MySqlColumn]) -> String {
@@ -205,7 +214,7 @@ fn write_header(writer: &mut StdWriter, schema: &String, url: &String) {
     writer.println("-- Database Dump Tool v0.2.0");
     writer.println("-- https://github.com/wcherry/dbdump");
     writer.println("-- ");
-    writer.println(format!("-- Created at {}", chrono::offset::Local::now()).as_str());
+    writer.println(format!("-- Created at {}", Local::now()).as_str());
     writer.println(format!("-- Schema: {}", schema).as_str());
     writer.println(format!("-- URL: {}", url).as_str());
     writer.println("-- -----------------------------------------------------------------------------------------");


### PR DESCRIPTION
Added support for most basic datatype and chrono types:
* BOOLEAN
* TINYINT
* SMALLINT
* INT
* BIGINT
* TINYINT UNSIGNED
* SMALLINT UNSIGNED
* INT UNSIGNED
* BIGINT UNSIGNED
* FLOAT
* DOUBLE
* CHAR
* VARCHAR
* TEXT
* TIMESTAMP
* DATETIME
* DATE
* TIME
* DECIMAL 
 
No support added for:
* VARBINARY
* BINARY
* BLOB
* UUID (except as a string)
* JSON (except as a string)

Update the build script to update the zip file name to include the application version. Added a flag `beta-skip-unknown-datatypes` to skip unknown datatypes.